### PR TITLE
Allow the CNAME records to be added with no configured TTL

### DIFF
--- a/roles/manage_local_records/tasks/process_record.yml
+++ b/roles/manage_local_records/tasks/process_record.yml
@@ -1,9 +1,9 @@
 ---
 - name: Process record on Pi-hole instance
   block:
-    - name: Manage A record
+    - name: Manage DNS record
       ansible.builtin.debug:
-        msg: "Processing A record {{ record.name }} on {{ pihole_instance.name }}"
+        msg: "Processing DNS record {{ record.name }} on {{ pihole_instance.name }}"
 
     - name: Manage A record
       sbarbett.pihole.local_a_record:
@@ -24,14 +24,10 @@
       when: record.type == "AAAA"
 
     - name: Manage CNAME record
-      ansible.builtin.debug:
-        msg: "Processing CNAME record {{ record.name }} on {{ pihole_instance.name }}"
-
-    - name: Manage CNAME record
       sbarbett.pihole.local_cname:
         host: "{{ record.name }}"
         target: "{{ record.data }}"
-        ttl: "{{ record.ttl | default(300) }}"
+        ttl: "{{ record.ttl | default(omit) }}"
         state: "{{ record.state }}"
         url: "{{ pihole_instance.name }}"
         password: "{{ pihole_instance.password }}"


### PR DESCRIPTION
Hello,

This PR is complementary to the other one I opened on the Pi-Hole API (https://github.com/sbarbett/pihole6api/pull/6).  These changes allow the CNAME `pihole_records` to not include a configured TTL.  I removed the TTL default of 300s.  If a user does not specify a TTL, it will be removed from the configuration.  The role allows you to add or remove the TTL configuration for individual CNAME records.

There is one change included which is not related to the objective of the PR.  In `roles/manage_local_records/tasks/process_record.yml` I removed the second `ansible.builtin.debug:` which was printing `Manage CNAME record` for all records.  In the first (now only) instance of `ansible.builtin.debug:` I adapted the text from "A record" to the more generic "DNS record" since this message was printed for all records already.

Please let me know if you have any questions about this change, or if you'd like me to make any other adaptions.