### PR TITLE
Fix minor typo in A record example

### DIFF
--- a/examples/create-a-record.yml
+++ b/examples/create-a-record.yml
@@ -11,7 +11,7 @@
         url: "https://your-pihole.example.com"
         password: "{{ pihole_password }}"
 
-    - name: Create test.example.com A record
+    - name: Create test.example.com AAAA record
       sbarbett.pihole.local_aaaa_record:
         host: test.example.com
         ip: 2001:db8::1


### PR DESCRIPTION
The task creating a AAAA record was named as if it created an A record.

Thanks for this neat project!