### PR TITLE
Task/14 add domain management support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-04-09
+
+### Added
+- New `domains.py` module for managing Pi-hole domains
+- Example playbooks:
+  - `manage-domains.yml` to demonstrate the domains module
+
 ## [1.1.2] - 2025-12-23
 
 ### Changed

--- a/examples/manage-domains.yml
+++ b/examples/manage-domains.yml
@@ -1,0 +1,43 @@
+- name: Manage Pi-hole domains
+  hosts: localhost
+  gather_facts: false
+  roles:
+    - role: sbarbett.pihole.domain_management
+      vars:
+        pihole_hosts:
+          - name: "https://your-pihole-1.example.com"
+            password: "{{ pihole_password }}"
+          - name: "https://your-pihole-2.example.com"
+            password: "{{ pihole_password }}"
+        
+        pihole_domains:
+          - domain: example.com
+            domain_type: deny
+            kind: exact
+            comment: Block example.com
+            groups:
+              - Default
+            enabled: true
+            state: present
+          - domain: "(\\.|^)googlevideo\\.com$"
+            domain_type: deny
+            kind: regex
+            comment: Google Video
+            groups: 
+              - Echos
+            enabled: false
+            state: present
+          - domain: 
+              - msh.amazon.com
+              - msh.amazon.co.uk
+              - arcus-uswest.amazon.com
+            domain_type: deny
+            kind: exact
+            groups: 
+              - Echos
+            enabled: True
+            state: present
+          - domain: old.example.com
+            domain_type: allow
+            kind: exact
+            state: absent

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: sbarbett
 name: pihole
-version: "1.1.2"
+version: "1.2.0"
 readme: README.md
 authors:
   - Shane Barbetta

--- a/plugins/modules/domains.py
+++ b/plugins/modules/domains.py
@@ -1,0 +1,467 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: domains
+short_description: Manage PiHole domains
+description:
+  - Create, update, or delete PiHole domains.
+version_added: "1.0.0"
+author:
+  - David Hutchison (@dhutchison)
+options:
+  domains:
+    description:
+      - List of domains to manage.
+    type: list
+    elements: dict
+    required: true
+    suboptions:
+      domain:
+        description:
+          - Domain name or list of domain names.
+        type: raw
+        required: true
+      domain_type:
+        description:
+          - Type of domain.
+        type: str
+        required: true
+        choices: [ allow, deny ]
+      kind:
+        description:
+          - Kind of domain.
+        type: str
+        required: true
+        choices: [ exact, regex ]
+      comment:
+        description:
+          - Comment for the domain.
+        type: str
+        required: false
+      groups:
+        description:
+          - List of group names or IDs to associate with the domain.
+          - Group names will be mapped to their corresponding IDs.
+        type: list
+        elements: raw
+        required: false
+        default: []
+      enabled:
+        description:
+          - Whether the domain is enabled.
+          - Defaults to true if not specified.
+        type: bool
+        required: false
+        default: true
+      state:
+        description:
+          - Whether the domain should exist or not.
+        type: str
+        required: true
+        choices: [ present, absent ]
+  url:
+    description:
+      - URL of the PiHole server.
+    type: str
+    required: true
+  password:
+    description:
+      - Password for the PiHole server.
+    type: str
+    required: true
+requirements:
+  - pihole6api
+'''
+
+EXAMPLES = r'''
+- name: Manage PiHole domains
+  sbarbett.pihole.domains:
+    domains:
+      - domain: example.com
+        domain_type: deny
+        kind: exact
+        comment: Block example.com
+        groups:
+          - Default
+        enabled: true
+        state: present
+      - domain: [test.example.com, bad.example.com]
+        domain_type: deny
+        kind: regex
+        comment: Block regex domains
+        groups:
+          - Default
+        enabled: false
+        state: present
+      - domain: old.example.com
+        domain_type: allow
+        kind: exact
+        state: absent
+    url: "https://pihole.example.com"
+    password: "admin_password"
+'''
+
+RETURN = r'''
+domains:
+  description: List of domains that were created, updated, or deleted.
+  returned: always
+  type: list
+  elements: dict
+  contains:
+    domain:
+      description: Domain name.
+      returned: always
+      type: str
+      sample: example.com
+    domain_type:
+      description: Type of the domain.
+      returned: always
+      type: str
+      sample: deny
+    kind:
+      description: Kind of the domain.
+      returned: always
+      type: str
+      sample: exact
+    comment:
+      description: Comment for the domain.
+      returned: always
+      type: str
+      sample: Block example.com
+    enabled:
+      description: Whether the domain is enabled.
+      returned: always
+      type: bool
+      sample: true
+    groups:
+      description: Groups associated with the domain.
+      returned: always
+      type: list
+      elements: raw
+      sample: ["Default"]
+    state:
+      description: State of the domain.
+      returned: always
+      type: str
+      sample: present
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
+
+try:
+    from pihole6api import PiHole6Client
+    HAS_PIHOLE6API = True
+except ImportError:
+    HAS_PIHOLE6API = False
+
+
+def get_existing_groups(client):
+    """
+    Get existing groups from PiHole.
+    """
+    try:
+        response = client.group_management.get_groups()
+        groups = response.get('groups', []) if isinstance(response, dict) else response
+        return {group['name']: group for group in groups}
+    except Exception:
+        return {}
+
+
+def map_groups_to_ids(module, group_items, existing_groups):
+    """
+    Map group names to their corresponding IDs.
+    If a group name doesn't exist, it will be ignored with a warning.
+    """
+    group_ids = []
+    missing_groups = []
+
+    for item in group_items or []:
+        if item is None:
+            continue
+
+        if isinstance(item, int):
+            group_ids.append(item)
+            continue
+
+        found = False
+        for group_name, details in existing_groups.items():
+            if group_name.lower() == str(item).lower():
+                group_ids.append(details['id'])
+                found = True
+                break
+
+        if not found:
+            missing_groups.append(str(item))
+
+    if missing_groups:
+        module.warn(f"The following groups were not found and will be ignored: {', '.join(missing_groups)}")
+
+    return group_ids
+
+
+def get_existing_domains(client):
+    """
+    Get existing domains from PiHole by type and kind.
+    """
+    existing = {}
+    for domain_type in ['allow', 'deny']:
+        for kind in ['exact', 'regex']:
+            try:
+                # This is doing a direct API call as the pihole6api doesn't handle regex domain results
+                response = client.domain_management.connection.get(f"domains/{domain_type}/{kind}")
+            except Exception:
+                continue
+
+            domains = []
+            if isinstance(response, dict):
+                if 'domains' in response and isinstance(response['domains'], list):
+                    domains = response['domains']
+                elif 'data' in response and isinstance(response['data'], list):
+                    domains = response['data']
+                elif isinstance(response.get('domain'), list):
+                    domains = response.get('domain')
+                elif isinstance(response.get('items'), list):
+                    domains = response.get('items')
+                else:
+                    if 'domain' in response or 'item' in response:
+                        domains = [response]
+                    else:
+                        for value in response.values():
+                            if isinstance(value, list):
+                                domains.extend(value)
+            elif isinstance(response, list):
+                domains = response
+
+            for domain in domains:
+                entry_domain = domain.get('domain') or domain.get('item') or domain.get('address') or domain.get('name')
+                if not entry_domain:
+                    continue
+                key = (entry_domain, domain_type, kind)
+                existing[key] = domain
+
+    return existing
+
+
+def normalize_domain_items(domains):
+    normalized = []
+    for item in domains:
+        raw_domain = item.get('domain')
+        if isinstance(raw_domain, list):
+            domain_values = raw_domain
+        else:
+            domain_values = [raw_domain]
+
+        for domain_value in domain_values:
+            normalized.append({
+                'domain': domain_value,
+                'domain_type': item['domain_type'],
+                'kind': item['kind'],
+                'comment': item.get('comment'),
+                'groups': item.get('groups', []),
+                'enabled': item.get('enabled', True),
+                'state': item['state'],
+            })
+
+    return normalized
+
+
+def create_domain(client, domain, domain_type, kind, comment=None, groups=None, enabled=True):
+    """
+    Create a new domain in PiHole.
+    """
+    try:
+        return client.domain_management.add_domain(domain, domain_type, kind, comment=comment, groups=groups, enabled=enabled)
+    except Exception as e:
+        return {'error': to_native(e)}
+
+
+def update_domain(client, domain, domain_type, kind, comment=None, groups=None, enabled=True):
+    """
+    Update an existing domain in PiHole.
+    """
+    try:
+        return client.domain_management.update_domain(domain, domain_type, kind, comment=comment, groups=groups, enabled=enabled)
+    except Exception as e:
+        return {'error': to_native(e)}
+
+
+def delete_domain(client, domain, domain_type, kind):
+    """
+    Delete a domain from PiHole.
+    """
+    try:
+        return client.domain_management.delete_domain(domain, domain_type, kind)
+    except Exception as e:
+        return {'error': to_native(e)}
+
+
+def batch_delete_domains(client, domains):
+    """
+    Delete multiple domains from PiHole.
+    """
+    try:
+        return client.domain_management.batch_delete_domains(domains)
+    except Exception as e:
+        return {'error': to_native(e)}
+
+
+def main():
+    module_args = dict(
+        domains=dict(
+            type='list',
+            elements='dict',
+            required=True,
+            options=dict(
+                domain=dict(type='raw', required=True),
+                domain_type=dict(type='str', required=True, choices=['allow', 'deny']),
+                kind=dict(type='str', required=True, choices=['exact', 'regex']),
+                comment=dict(type='str', required=False, default=None),
+                groups=dict(type='list', elements='raw', required=False, default=[]),
+                enabled=dict(type='bool', required=False, default=True),
+                state=dict(type='str', required=True, choices=['present', 'absent']),
+            ),
+        ),
+        url=dict(type='str', required=True),
+        password=dict(type='str', required=True, no_log=True),
+    )
+
+    result = dict(
+        changed=False,
+        domains=[],
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    if not HAS_PIHOLE6API:
+        module.fail_json(msg='The pihole6api module is required')
+
+    url = module.params['url']
+    password = module.params['password']
+    domains = module.params['domains']
+
+    client = None
+    try:
+        client = PiHole6Client(url, password)
+
+        existing_groups = get_existing_groups(client)
+        existing_domains = get_existing_domains(client)
+        normalized_domains = normalize_domain_items(domains)
+
+        domains_to_delete = [item for item in normalized_domains
+                             if item['state'] == 'absent'
+                             and (item['domain'], item['domain_type'], item['kind']) in existing_domains]
+
+        for item in normalized_domains:
+            name = item['domain']
+            domain_type = item['domain_type']
+            kind = item['kind']
+            comment = item.get('comment')
+            enabled = item.get('enabled', True)
+            group_ids = map_groups_to_ids(module, item.get('groups', []), existing_groups)
+            key = (name, domain_type, kind)
+
+            if item['state'] == 'present':
+                if key not in existing_domains:
+                    if not module.check_mode:
+                        response = create_domain(client, name, domain_type, kind, comment, group_ids, enabled)
+                        if 'error' in response:
+                            module.fail_json(msg=f'Failed to create domain {name}: {response["error"]}')
+                    result['changed'] = True
+                    result['domains'].append({
+                        'domain': name,
+                        'domain_type': domain_type,
+                        'kind': kind,
+                        'comment': comment,
+                        'enabled': enabled,
+                        'groups': item.get('groups', []),
+                        'state': 'created'
+                    })
+                else:
+                    existing = existing_domains[key]
+                    update_needed = False
+
+                    if comment is not None and existing.get('comment') != comment:
+                        update_needed = True
+
+                    if existing.get('enabled') != enabled:
+                        update_needed = True
+
+                    existing_group_ids = set(existing.get('groups', []) or [])
+                    if existing_group_ids != set(group_ids):
+                        update_needed = True
+
+                    if update_needed:
+                        if not module.check_mode:
+                            response = update_domain(client, name, domain_type, kind, comment, group_ids, enabled)
+                            if 'error' in response:
+                                module.fail_json(msg=f'Failed to update domain {name}: {response["error"]}')
+                        result['changed'] = True
+                        result['domains'].append({
+                            'domain': name,
+                            'domain_type': domain_type,
+                            'kind': kind,
+                            'comment': comment,
+                            'enabled': enabled,
+                            'groups': item.get('groups', []),
+                            'state': 'updated'
+                        })
+                    else:
+                        result['domains'].append({
+                            'domain': name,
+                            'domain_type': domain_type,
+                            'kind': kind,
+                            'comment': existing.get('comment'),
+                            'enabled': existing.get('enabled'),
+                            'groups': item.get('groups', []),
+                            'state': 'unchanged'
+                        })
+
+        if domains_to_delete:
+            result['changed'] = True
+            for item in domains_to_delete:
+                result['domains'].append({
+                    'domain': item['domain'],
+                    'domain_type': item['domain_type'],
+                    'kind': item['kind'],
+                    'state': 'deleted'
+                })
+
+            if not module.check_mode:
+                if len(domains_to_delete) == 1:
+                    response = delete_domain(client, domains_to_delete[0]['domain'],
+                                             domains_to_delete[0]['domain_type'],
+                                             domains_to_delete[0]['kind'])
+                    if 'error' in response:
+                        module.fail_json(msg=f'Failed to delete domain {domains_to_delete[0]["domain"]}: {response["error"]}')
+                else:
+                    delete_items = [
+                        {
+                            'item': item['domain'],
+                            'type': item['domain_type'],
+                            'kind': item['kind']
+                        }
+                        for item in domains_to_delete
+                    ]
+                    response = batch_delete_domains(client, delete_items)
+                    if 'error' in response:
+                        module.fail_json(msg=f'Failed to delete domains: {response["error"]}')
+
+        module.exit_json(**result)
+    except Exception as e:
+        module.fail_json(msg=f'Error managing domains: {to_native(e)}', **result)
+    finally:
+        if client is not None:
+            client.close_session()
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/domain_management/README.md
+++ b/roles/domain_management/README.md
@@ -1,0 +1,87 @@
+# domain_management
+
+This role manages Pi-hole domains (allow/deny lists) across multiple Pi-hole instances. It processes domains using batch processing for efficiency, supporting both exact and regex domain types.
+
+## Overview
+
+- Manage domains on multiple Pi-hole instances using batch processing
+- Ensure idempotent operations: domains are created, updated, or removed based on the desired state
+- Support for exact and regex domain matching
+- Associate domains with groups using human-readable group names
+- Handle multiple domains per entry (e.g., lists of domains)
+
+## Requirements
+
+- **Ansible:** 2.9 or later
+- **Python:** The control node must have the `pihole6api` library installed
+- **Pi-hole API Access:** Each Pi-hole instance must be accessible with a valid URL and API password
+
+## Role Variables
+
+### `pihole_hosts`
+
+A list of dictionaries representing the Pi-hole instances you want to manage. Each dictionary should include:
+
+- `name`: The URL of the Pi-hole instance (e.g., `https://pi.hole`)
+- `password`: The API password for the instance
+
+### `pihole_domains`
+
+A list of domain definitions. Each domain is a dictionary with the following keys:
+
+* `domain`: The domain name (string) or list of domain names (array of strings)
+* `domain_type`: The type of domain. Allowed values are `allow` or `deny`
+* `kind`: The kind of domain. Allowed values are `exact` or `regex`
+* `comment`: (Optional) A comment describing the domain
+* `groups`: (Optional) A list of group names to associate with the domain
+* `enabled`: (Optional) Whether the domain is enabled. Default is `true`
+* `state`: Desired state for the domain. Allowed values are `present` or `absent`
+
+## Example Playbook
+
+```yaml
+---
+- name: Manage Pi-hole domains
+  hosts: localhost
+  gather_facts: false
+  roles:
+    - role: sbarbett.pihole.domain_management
+      vars:
+        pihole_hosts:
+          - name: "https://your-pihole-1.example.com"
+            password: "{{ pihole_password }}"
+          - name: "https://your-pihole-2.example.com"
+            password: "{{ pihole_password }}"
+        
+        pihole_domains:
+          - domain: example.com
+            domain_type: deny
+            kind: exact
+            comment: Block example.com
+            groups:
+              - Default
+            enabled: true
+            state: present
+          - domain: "(\\.|^)googlevideo\\.com$"
+            domain_type: deny
+            kind: regex
+            comment: Google Video
+            groups: 
+              - Echos
+            enabled: false
+            state: present
+          - domain: 
+              - msh.amazon.com
+              - msh.amazon.co.uk
+              - arcus-uswest.amazon.com
+            domain_type: deny
+            kind: exact
+            groups: 
+              - Echos
+            enabled: True
+            state: present
+          - domain: old.example.com
+            domain_type: allow
+            kind: exact
+            state: absent
+```

--- a/roles/domain_management/defaults/main.yml
+++ b/roles/domain_management/defaults/main.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT-0
+---
+# defaults file for collections/ansible_collections/sbarbett/pihole/roles/domain_management

--- a/roles/domain_management/handlers/main.yml
+++ b/roles/domain_management/handlers/main.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT-0
+---
+# handlers file for collections/ansible_collections/sbarbett/pihole/roles/domain_management

--- a/roles/domain_management/meta/main.yml
+++ b/roles/domain_management/meta/main.yml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT-0
+galaxy_info:
+  author: Shane Barbetta
+  description: >
+    An Ansible role that manages Pi-hole domains across multiple Pi-hole instances.
+  license: MIT
+  min_ansible_version: "2.9"
+  galaxy_tags:
+    - pihole
+    - dns
+    - networking
+    - adblock
+
+dependencies: []

--- a/roles/domain_management/tasks/main.yml
+++ b/roles/domain_management/tasks/main.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT-0
+---
+# tasks file for collections/ansible_collections/sbarbett/pihole/roles/domain_management
+
+- name: Process each Pi-hole instance
+  ansible.builtin.include_tasks:
+    file: process_instance.yml
+  loop: "{{ pihole_hosts }}"
+  loop_control:
+    loop_var: pihole_instance

--- a/roles/domain_management/tasks/process_instance.yml
+++ b/roles/domain_management/tasks/process_instance.yml
@@ -1,0 +1,17 @@
+---
+- name: Process domains on {{ pihole_instance.name }}
+  sbarbett.pihole.domains:
+    domains: "{{ pihole_domains }}"
+    url: "{{ pihole_instance.name }}"
+    password: "{{ pihole_instance.password }}"
+  when: pihole_domains is defined and pihole_domains | length > 0
+  register: domains_result
+
+- name: Display domains result for {{ pihole_instance.name }}
+  ansible.builtin.debug:
+    msg:
+      - "Domains processed: {{ domains_result.domains | default([]) | length
+          if pihole_domains is defined and pihole_domains | length > 0 else 0 }}"
+      - "Changes made: {{ domains_result.changed | default(false) }}"
+      - "Changed domains: {{ domains_result.domains | selectattr('state', 'in', ['created', 'updated', 'deleted'])
+          | list | length if domains_result.changed else 0 }}"

--- a/roles/domain_management/vars/main.yml
+++ b/roles/domain_management/vars/main.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT-0
+---
+# vars file for collections/ansible_collections/sbarbett/pihole/roles/domain_management


### PR DESCRIPTION
Fixes #14 

This adds a new module for domain management (for custom domain allow/block outside the lists). I've tried to base this all on the structure of the groups module, but if there is anything amiss then let me know. 

I've tested this locally with this playbook (using a fresh pihole docker instance)

```
---
- name: Manage Pi-hole local records
  hosts: localhost
  gather_facts: false
  vars:
    pihole_hosts:
      - name: "http://127.0.0.1:8080"
        password: "correct horse battery staple"
  roles:
    - role: sbarbett.pihole.group_client_manager
      vars:
        pihole_groups:
          - name: Default
            comment: "The default group"
            enabled: true
            state: present
          - name: IOT
            comment: "Internet of Things devices"
            enabled: true
            state: present
          - name: Restricted
            comment: "Restricted access devices"
            enabled: false
            state: present
          - name: Echos
            comment: Amazon Echo Devices
            enabled: true
            state: present
          - name: Free-Access
            comment: Group with no restrictions
            enabled: true
            state: present
          - name: Plex-Clients
            comment: ""
            enabled: true
            state: present

    - role: sbarbett.pihole.domain_management
      vars:
        pihole_domains:
          - domain:
              - watson.telemetry.microsoft.com
              - v10.vortex-win.data.microsoft.com
              - v10.events.data.microsoft.com
            domain_type: allow
            kind: exact
            groups: 
              - Default
            enabled: True
            state: present

          - domain:
              - analytics.google.com
              - www.googleadservices.com
              - www.google-analytics.com
            domain_type: allow
            kind: exact
            groups: 
              - Default
            enabled: True
            state: present

          - domain: 
              - msh.amazon.com
              - msh.amazon.co.uk
              - arcus-uswest.amazon.com
            domain_type: deny
            kind: exact
            groups: 
              - Echos
            enabled: True
            state: present
          - domain: "(\\.|^)amazonvideo\\.com$"
            domain_type: deny
            kind: regex
            comment: Prime video
            groups: 
              - Echos
            enabled: True
            state: present
          - domain: "(\\.|^)youtube\\.com$"
            domain_type: deny
            kind: regex
            comment: YouTube
            groups: 
              - Echos
            enabled: True
            state: present
          - domain: "(\\.|^)googlevideo\\.com$"
            domain_type: deny
            kind: regex
            comment: Google Video
            groups: 
              - Echos
            enabled: True
            state: present
          - domain: "*.provider.plex.tv"
            domain_type: deny
            kind: regex
            groups: 
              - Plex-Clients
            enabled: True
            state: present
          - domain: example.com
            domain_type: deny
            kind: exact
            comment: Block example.com
            groups:
              - Default
            enabled: true
            state: absent
          - domain: [test.example.com, bad.example.com]
            domain_type: deny
            kind: regex
            comment: Block regex domains
            groups:
              - Default
            enabled: false
            state: absent
          - domain: old.example.com
            domain_type: allow
            kind: exact
            state: absent
```